### PR TITLE
Reflect endpoint has no side effects

### DIFF
--- a/buf/reflect/v1beta1/file_descriptor_set.proto
+++ b/buf/reflect/v1beta1/file_descriptor_set.proto
@@ -31,7 +31,9 @@ service FileDescriptorSetService {
   // GetFileDescriptorSet returns a set of file descriptors that can be used to build
   // dynamic representations of a schema and/or service interfaces. This can also be
   // used for server reflection.
-  rpc GetFileDescriptorSet(GetFileDescriptorSetRequest) returns (GetFileDescriptorSetResponse);
+  rpc GetFileDescriptorSet(GetFileDescriptorSetRequest) returns (GetFileDescriptorSetResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 message GetFileDescriptorSetRequest {


### PR DESCRIPTION
This setting will enable the use of HTTP GET with this endpoint, so implementations can support caching and conditional GETs.